### PR TITLE
add empty reason to transfer example as it is required

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@ MAIN_CITIZENSHIP=Russian Federation
 NUMBER_OF_PEOPLE=one person
 LIVE_WITH=no
 CATEGORY=transfer
+REASON=empty
 PURPOSE=transfer_blue_card_eu
 ```
 


### PR DESCRIPTION
Instead of what is stated in the example of a transfer existing residence permit the program checks for the `REASON` field in the `.env` and crashes when can't find it. [Link to the code](https://github.com/dmitry-kostin/termin-buchen/blob/0a8eb1ac0aa99a9badb6ec98b7fb4c8ea2804e0b/src/config/config.ts#L44-L51). This PR adds the `REASON=empty` to the example to make the program happy. Tested locally.